### PR TITLE
fixed build issues

### DIFF
--- a/raml-to-jaxrs/examples/jersey-example/pom.xml
+++ b/raml-to-jaxrs/examples/jersey-example/pom.xml
@@ -14,7 +14,7 @@
 
     <properties>
         <jersey.version>2.4.1</jersey.version>
-        <licensePath>../LICENSE_HEADER.txt</licensePath>
+        <licensePath>../../LICENSE_HEADER.txt</licensePath>
     </properties>
 
     <dependencies>

--- a/raml-to-jaxrs/examples/jersey-example/src/main/java/org/raml/jaxrs/example/impl/PresentationResource.java
+++ b/raml-to-jaxrs/examples/jersey-example/src/main/java/org/raml/jaxrs/example/impl/PresentationResource.java
@@ -83,8 +83,10 @@ public class PresentationResource implements Presentations
     }
 
     @Override
-    public void deletePresentationsByPresentationId(final String presentationId, final String authorization)
+    public DeletePresentationsByPresentationIdResponse deletePresentationsByPresentationId(final String presentationId, final String authorization)
     {
         // TODO implement me!
+    	return null;
     }
+    
 }

--- a/raml-to-jaxrs/pom.xml
+++ b/raml-to-jaxrs/pom.xml
@@ -10,7 +10,7 @@
     <modules>
         <module>core</module>
         <module>maven-plugin</module>
-        <module>jersey-example</module>
+        <module>examples/jersey-example</module>
     </modules>
 
     <properties>
@@ -38,6 +38,8 @@
                         <exclude>**/*.properties</exclude>
                         <exclude>**/*.md</exclude>
                         <exclude>**/*.template</exclude>
+                        <exclude>**/*.buildpath</exclude>
+                        <exclude>**/example-output/**</exclude>
                     </excludes>
                     <mapping>
                         <java>SLASHSTAR_STYLE</java>


### PR DESCRIPTION
  1) jersey-example was moved under examples so updated in raml-jaxrs-codegen-parent pom file
  2) filtered out license file check for files under example-output
  3) fixed deletePresentationsByPresentationId(String, String) return type to conform to required interface
