### PR TITLE
print line and column numbers when RAML validation fails during generation

### DIFF
--- a/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/Generator.java
+++ b/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/Generator.java
@@ -135,13 +135,41 @@ public class Generator
                     
                     public String apply(final ValidationResult vr)
                     {
-                        return String.format("%s %s", vr.getStartColumn(), vr.getMessage());
+                        return toDetailedString(vr);
                     }
                 });
 
             throw new IllegalArgumentException("Invalid RAML definition:\n" + join(validationErrors, "\n"));
         }
     }
+    
+    
+    private static String toDetailedString(ValidationResult item)
+    {
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append("\t");
+        stringBuilder.append(item.getLevel());
+        stringBuilder.append(" ");
+        stringBuilder.append(item.getMessage());
+        if (item.getLine() != -1)
+        {
+            stringBuilder.append(" (line ");
+            stringBuilder.append(item.getLine());
+            if (item.getStartColumn() != -1)
+            {
+                stringBuilder.append(", col ");
+                stringBuilder.append(item.getStartColumn());
+                if (item.getEndColumn() != item.getStartColumn())
+                {
+                    stringBuilder.append(" to ");
+                    stringBuilder.append(item.getEndColumn());
+                }
+            }
+            stringBuilder.append(")");
+        }
+        return stringBuilder.toString();
+    }    
+    
 
 	private ResourceLoader[] prepareResourceLoaders(final Configuration configuration)
 	{


### PR DESCRIPTION
Note: this code was cut and pasted from raml-java-parser.  I debated pulling the code in the parser into a public function but decided to make the minimal change for now.  If you want me to make the change in raml-java-parser, I can do that instead.

Also, there seems to be a bug with line number reporting in the parser.  It seems to be okay if the error is in the RAML, but is off by one if it is in an included schema.   
