### PR TITLE
Code generator extension mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+=======
 ![](http://raml.org/images/logo.png)
 RAML for JAX-RS
 ===============
@@ -134,3 +135,5 @@ and with `@Min`/`@Max` support limited to non decimal minimum/maximum constraint
 If you are interested in contributing some code to this project, thanks! Please submit a [Contributors Agreement](https://api-notebook.anypoint.mulesoft.com/notebooks#bc1cf75a0284268407e4) acknowledging that you are transferring ownership.
 
 To discuss this project, please use its github issues or the [RAML forum](http://forums.raml.org/).
+
+

--- a/maven-plugin.md
+++ b/maven-plugin.md
@@ -68,6 +68,14 @@ You must include the plug-in in your project's pom.xml. For example:
         <!-- Valid values: jackson1 jackson2 gson none -->
         <jsonMapper>jackson2</jsonMapper>
         <removeOldOutput>true</removeOldOutput>
+        <!-- Optionally set extensions to a list of fully qualified names of classes
+        that implement org.raml.jaxrs.codegen.core.ext.GeneratorExtension -->
+        <!-- for example:
+		<extensions>
+			<param>com.abc.AuthorizationAnnotationExtension</param>
+		    <param>com.abc.ParameterFilterExtension</param>
+		</extensions>
+        -->
     </configuration>
     <executions>
         <execution>

--- a/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/Configuration.java
+++ b/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/Configuration.java
@@ -24,6 +24,8 @@ import org.apache.commons.lang.StringUtils;
 import org.jsonschema2pojo.AnnotationStyle;
 import org.jsonschema2pojo.DefaultGenerationConfig;
 import org.jsonschema2pojo.GenerationConfig;
+import org.raml.jaxrs.codegen.core.ext.AbstractGeneratorExtension;
+import org.raml.jaxrs.codegen.core.ext.GeneratorExtension;
 
 public class Configuration
 {
@@ -66,6 +68,8 @@ public class Configuration
     private Map<String, String> jsonMapperConfiguration;
     private String asyncResourceTrait;
 	private boolean emptyResponseReturnVoid;
+	
+	private List<GeneratorExtension> extensions = new ArrayList<GeneratorExtension>();
     
     
 
@@ -214,4 +218,10 @@ public class Configuration
 	public void setEmptyResponseReturnVoid(boolean emptyResponseReturnVoid) {
 		this.emptyResponseReturnVoid = emptyResponseReturnVoid;
 	}
+	
+	public List<GeneratorExtension> getExtensions() {
+		return this.extensions;
+	}
+	
+
 }

--- a/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/ext/AbstractGeneratorExtension.java
+++ b/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/ext/AbstractGeneratorExtension.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2013 (c) MuleSoft, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+package org.raml.jaxrs.codegen.core.ext;
+
+import java.lang.annotation.Annotation;
+import java.util.Collection;
+
+import org.raml.model.Action;
+import org.raml.model.MimeType;
+import org.raml.model.Raml;
+import org.raml.model.Resource;
+import org.raml.model.parameter.AbstractParam;
+
+import com.sun.codemodel.JDefinedClass;
+import com.sun.codemodel.JMethod;
+
+
+/**
+ * Generator extensions can extend this class
+ * @author pbober
+ *
+ */
+public abstract class AbstractGeneratorExtension implements GeneratorExtension {
+
+	private Raml raml;
+	
+	public void onAddResourceMethod(JMethod method,  Action action,  MimeType bodyMimeType,
+			 Collection<MimeType> uniqueResponseMimeTypes) {
+
+		
+	}
+
+	public void onCreateResourceInterface(JDefinedClass resourceInterface, Resource resource) {
+
+		
+	}
+
+	public boolean AddParameterFilter(String name,
+             AbstractParam parameter,
+             Class<? extends Annotation> annotationClass,
+             JMethod method) {
+		return true;
+	}
+
+	public void setRaml(Raml raml) {
+		this.raml = raml;
+	}
+	
+	protected  Raml getRaml() {
+		return raml;
+	}
+}

--- a/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/ext/GeneratorExtension.java
+++ b/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/ext/GeneratorExtension.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2013 (c) MuleSoft, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+package org.raml.jaxrs.codegen.core.ext;
+
+import java.lang.annotation.Annotation;
+import java.util.Collection;
+
+import org.raml.model.Action;
+import org.raml.model.MimeType;
+import org.raml.model.Raml;
+import org.raml.model.Resource;
+import org.raml.model.parameter.AbstractParam;
+
+import com.sun.codemodel.JDefinedClass;
+import com.sun.codemodel.JMethod;
+
+public interface GeneratorExtension {
+
+	
+	/**
+	 * Called after a class is added to the Java model by the code generator
+	 * @param resourceInterface
+	 * @param resource
+	 */
+	public void onCreateResourceInterface(final JDefinedClass resourceInterface, Resource resource);
+	
+	/**
+	 * Called after a method is added to the Java model by the code generator
+	 * @param method
+	 * @param action
+	 * @param bodyMimeType
+	 * @param uniqueResponseMimeTypes
+	 */
+	public void onAddResourceMethod(final JMethod method, final Action action, 
+			final MimeType bodyMimeType, final Collection<MimeType> uniqueResponseMimeTypes);
+	
+	/**
+	 * Called to decide if a given parameter should be added to a method.  Is used to avoid passing request parameters to a method (or response parameteres from a method) if
+	 * the parameter is handled solely in a servlet filter.
+	 * @param name
+	 * @param parameter
+	 * @param annotationClass
+	 * @param method
+	 * @return true if the parameter should be added; false if it is should be ignored
+	 */
+	public boolean AddParameterFilter(final String name,
+            final AbstractParam parameter,
+            final Class<? extends Annotation> annotationClass,
+            final JMethod method);
+	
+	
+	/**
+	 * Sets the {@link Raml}.
+	 * 
+	 * @param raml
+	 */
+	void setRaml(Raml raml);
+}

--- a/raml-to-jaxrs/core/src/test/java/org/raml/jaxrs/codegen/core/ResponseWrapperGeneratorTestCase.java
+++ b/raml-to-jaxrs/core/src/test/java/org/raml/jaxrs/codegen/core/ResponseWrapperGeneratorTestCase.java
@@ -118,11 +118,9 @@ public class ResponseWrapperGeneratorTestCase
         final FileResourceStore classWriter = new FileResourceStore(compilationOutputFolder.getRoot());
         final CompilationResult result = compiler.compile(sources, sourceReader, classWriter,
             Thread.currentThread().getContextClassLoader(), settings);
-
         CompilationProblem[] errors = result.getErrors();
 		assertThat(ToStringBuilder.reflectionToString(errors, ToStringStyle.SHORT_PREFIX_STYLE),
             errors, is(emptyArray()));
-
         assertThat(
             ToStringBuilder.reflectionToString(result.getWarnings(), ToStringStyle.SHORT_PREFIX_STYLE),
             result.getWarnings(), is(emptyArray()));

--- a/raml-to-jaxrs/core/src/test/java/org/raml/jaxrs/codegen/core/ext/TestAnnotation.java
+++ b/raml-to-jaxrs/core/src/test/java/org/raml/jaxrs/codegen/core/ext/TestAnnotation.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2013 (c) MuleSoft, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+package org.raml.jaxrs.codegen.core.ext;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface TestAnnotation {
+
+}

--- a/raml-to-jaxrs/core/src/test/java/org/raml/jaxrs/codegen/core/ext/TestGeneratorExtension.java
+++ b/raml-to-jaxrs/core/src/test/java/org/raml/jaxrs/codegen/core/ext/TestGeneratorExtension.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2013 (c) MuleSoft, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+/**
+ * A test extension that annotates each method and class with @TestAnnotation
+ */
+package org.raml.jaxrs.codegen.core.ext;
+
+import java.lang.annotation.Annotation;
+import java.util.Collection;
+
+import org.raml.model.Action;
+import org.raml.model.MimeType;
+import org.raml.model.Raml;
+import org.raml.model.Resource;
+import org.raml.model.parameter.AbstractParam;
+
+import com.sun.codemodel.JDefinedClass;
+import com.sun.codemodel.JMethod;
+
+public class TestGeneratorExtension implements GeneratorExtension {
+
+	@Override
+	public void onCreateResourceInterface(JDefinedClass resourceInterface, Resource resource) {
+
+		resourceInterface.annotate(TestAnnotation.class);
+	}
+
+	@Override
+	public void onAddResourceMethod(JMethod method, Action action, MimeType bodyMimeType,
+			Collection<MimeType> uniqueResponseMimeTypes) {
+
+		method.annotate(TestAnnotation.class);
+		
+	}
+
+	@Override
+	public void setRaml(Raml raml) {
+		
+	}
+
+	@Override
+	public boolean AddParameterFilter(String name, AbstractParam parameter,
+			Class<? extends Annotation> annotationClass, JMethod method) {
+		return true;
+	}
+}

--- a/raml-to-jaxrs/maven-plugin/src/main/java/org/raml/jaxrs/codegen/maven/RamlJaxrsCodegenMojo.java
+++ b/raml-to-jaxrs/maven-plugin/src/main/java/org/raml/jaxrs/codegen/maven/RamlJaxrsCodegenMojo.java
@@ -37,195 +37,198 @@ import org.jsonschema2pojo.AnnotationStyle;
 import org.raml.jaxrs.codegen.core.Configuration;
 import org.raml.jaxrs.codegen.core.Configuration.JaxrsVersion;
 import org.raml.jaxrs.codegen.core.Generator;
+import org.raml.jaxrs.codegen.core.ext.GeneratorExtension;
 
 /**
- * When invoked, this goals read one or more <a href="http://raml.org">RAML</a> files and produces
- * JAX-RS annotated Java classes.
+ * When invoked, this goals read one or more <a href="http://raml.org">RAML</a>
+ * files and produces JAX-RS annotated Java classes.
  */
 @Mojo(name = "generate", requiresProject = true, threadSafe = false, requiresDependencyResolution = COMPILE_PLUS_RUNTIME, defaultPhase = LifecyclePhase.GENERATE_SOURCES)
-public class RamlJaxrsCodegenMojo extends AbstractMojo
-{
-    @Parameter(defaultValue = "${project}")
-    private MavenProject project;
+public class RamlJaxrsCodegenMojo extends AbstractMojo {
+	@Parameter(defaultValue = "${project}")
+	private MavenProject project;
 
-    /**
-     * Skip plug-in execution.
-     */
-    @Parameter(property = "skip", defaultValue = "false")
-    private boolean skip;
+	/**
+	 * Skip plug-in execution.
+	 */
+	@Parameter(property = "skip", defaultValue = "false")
+	private boolean skip;
 
-    /**
-     * Target directory for generated Java source files.
-     */
-    @Parameter(property = "outputDirectory", defaultValue = "${project.build.directory}/generated-sources/raml-jaxrs")
-    private File outputDirectory;
+	/**
+	 * Target directory for generated Java source files.
+	 */
+	@Parameter(property = "outputDirectory", defaultValue = "${project.build.directory}/generated-sources/raml-jaxrs")
+	private File outputDirectory;
 
-    /**
-     * An array of locations of the RAML file(s).
-     */
-    @Parameter(property = "sourcePaths")
-    private File[] sourcePaths;
+	/**
+	 * An array of locations of the RAML file(s).
+	 */
+	@Parameter(property = "sourcePaths")
+	private File[] sourcePaths;
 
-    /**
-     * Directory location of the RAML file(s).
-     */
-    @Parameter(property = "sourceDirectory", defaultValue = "${basedir}/src/main/raml")
-    private File sourceDirectory;
+	/**
+	 * Directory location of the RAML file(s).
+	 */
+	@Parameter(property = "sourceDirectory", defaultValue = "${basedir}/src/main/raml")
+	private File sourceDirectory;
 
-    /**
-     * The targeted JAX-RS version: either "1.1" or "2.0" .
-     */
-    @Parameter(property = "jaxrsVersion", defaultValue = "1.1")
-    private String jaxrsVersion;
+	/**
+	 * The targeted JAX-RS version: either "1.1" or "2.0" .
+	 */
+	@Parameter(property = "jaxrsVersion", defaultValue = "1.1")
+	private String jaxrsVersion;
 
-    /**
-     * Base package name used for generated Java classes.
-     */
-    @Parameter(property = "basePackageName", required = true)
-    private String basePackageName;
+	/**
+	 * Base package name used for generated Java classes.
+	 */
+	@Parameter(property = "basePackageName", required = true)
+	private String basePackageName;
 
-    /**
-     * Should JSR-303 annotations be used?
-     */
-    @Parameter(property = "useJsr303Annotations", defaultValue = "false")
-    private boolean useJsr303Annotations;
-    
-    
-    /**
-     * The targeted JAX-RS version: either "1.1" or "2.0" .
-     */
-    @Parameter(property = "mapToVoid", defaultValue = "false")
-    private boolean mapToVoid;
+	/**
+	 * Should JSR-303 annotations be used?
+	 */
+	@Parameter(property = "useJsr303Annotations", defaultValue = "false")
+	private boolean useJsr303Annotations;
 
-    /**
-     * Whether to empty the output directory before generation occurs, to clear out all source files
-     * that have been generated previously.
-     */
-    @Parameter(property = "removeOldOutput", defaultValue = "false")
-    private boolean removeOldOutput;
+	/**
+	 * The targeted JAX-RS version: either "1.1" or "2.0" .
+	 */
+	@Parameter(property = "mapToVoid", defaultValue = "false")
+	private boolean mapToVoid;
 
-    /**
-     * The JSON object mapper to generate annotations to: either "jackson1", "jackson2" or "gson" or
-     * "none"
-     */
-    @Parameter(property = "jsonMapper", defaultValue = "jackson1")
-    private String jsonMapper;
-    
-    
-    @Parameter(property = "asyncResourceTrait")
-    private String asyncResourceTrait;
-    /**
-    * Optional extra configuration provided to the JSON mapper. Supported keys are:
-    * "generateBuilders", "includeHashcodeAndEquals", "includeToString", "useLongIntegers"
-    */
-    @Parameter(property = "jsonMapperConfiguration")
-    private Map<String, String> jsonMapperConfiguration;
-    
-    /**
-    * Throw exception on Resource Method
-    */
-    //@Parameter(property = "methodThrowException")
-    //private String methodThrowException;
+	/**
+	 * Whether to empty the output directory before generation occurs, to clear
+	 * out all source files that have been generated previously.
+	 */
+	@Parameter(property = "removeOldOutput", defaultValue = "false")
+	private boolean removeOldOutput;
 
-    @Override
-    public void execute() throws MojoExecutionException, MojoFailureException
-    {
-        if (skip)
-        {
-            getLog().info("Skipping execution...");
-            return;
-        }
+	/**
+	 * The JSON object mapper to generate annotations to: either "jackson1",
+	 * "jackson2" or "gson" or "none"
+	 */
+	@Parameter(property = "jsonMapper", defaultValue = "jackson1")
+	private String jsonMapper;
 
-        if ((sourceDirectory == null) && (sourcePaths == null))
-        {
-            throw new MojoExecutionException("One of sourceDirectory or sourcePaths must be provided");
-        }
+	@Parameter(property = "asyncResourceTrait")
+	private String asyncResourceTrait;
+	/**
+	 * Optional extra configuration provided to the JSON mapper. Supported keys
+	 * are: "generateBuilders", "includeHashcodeAndEquals", "includeToString",
+	 * "useLongIntegers"
+	 */
+	@Parameter(property = "jsonMapperConfiguration")
+	private Map<String, String> jsonMapperConfiguration;
 
-        try
-        {
-            FileUtils.forceMkdir(outputDirectory);
-        }
-        catch (final IOException ioe)
-        {
-            throw new MojoExecutionException("Failed to create directory: " + outputDirectory, ioe);
-        }
+	/**
+	 * The name of a generator extension class (implements
+	 * org.raml.jaxrs.codegen.core.ext.GeneratorExtension)
+	 */
+	@Parameter(property = "extensions")
+	private String[] extensions;
 
-        if (removeOldOutput)
-        {
-            try
-            {
-                FileUtils.cleanDirectory(outputDirectory);
-            }
-            catch (final IOException ioe)
-            {
-                throw new MojoExecutionException("Failed to clean directory: " + outputDirectory, ioe);
-            }
-        }
+	/**
+	 * Throw exception on Resource Method
+	 */
+	// @Parameter(property = "methodThrowException")
+	// private String methodThrowException;
 
-        final Configuration configuration = new Configuration();
+	@Override
+	public void execute() throws MojoExecutionException, MojoFailureException {
+		if (skip) {
+			getLog().info("Skipping execution...");
+			return;
+		}
 
-        try
-        {
-            configuration.setBasePackageName(basePackageName);
-            configuration.setJaxrsVersion(JaxrsVersion.fromAlias(jaxrsVersion));
-            configuration.setOutputDirectory(outputDirectory);
-            configuration.setUseJsr303Annotations(useJsr303Annotations);
-            configuration.setAsyncResourceTrait(asyncResourceTrait);
-            configuration.setJsonMapper(AnnotationStyle.valueOf(jsonMapper.toUpperCase()));
-            configuration.setSourceDirectory(sourceDirectory);
-            configuration.setJsonMapperConfiguration(jsonMapperConfiguration);
-            configuration.setEmptyResponseReturnVoid(mapToVoid);
-            /*
-            if (methodThrowException != null) {
-                configuration.setMethodThrowException(Class.forName(methodThrowException));
-            }
-            */
-        }
-        catch (final Exception e)
-        {
-            throw new MojoExecutionException("Failed to configure plug-in", e);
-        }
+		if ((sourceDirectory == null) && (sourcePaths == null)) {
+			throw new MojoExecutionException("One of sourceDirectory or sourcePaths must be provided");
+		}
 
-        project.addCompileSourceRoot(outputDirectory.getPath());
+		try {
+			FileUtils.forceMkdir(outputDirectory);
+		} catch (final IOException ioe) {
+			throw new MojoExecutionException("Failed to create directory: " + outputDirectory, ioe);
+		}
 
-        File currentSourcePath = null;
+		if (removeOldOutput) {
+			try {
+				FileUtils.cleanDirectory(outputDirectory);
+			} catch (final IOException ioe) {
+				throw new MojoExecutionException("Failed to clean directory: " + outputDirectory, ioe);
+			}
+		}
 
-        try
-        {
-            final Generator generator = new Generator();
+		final Configuration configuration = new Configuration();
 
-            for (final File ramlFile : getRamlFiles())
-            {
-                getLog().info("Generating Java classes from: " + ramlFile);
-                currentSourcePath = ramlFile;
-                generator.run(new FileReader(ramlFile), configuration);
-            }
-        }
-        catch (final Exception e)
-        {
-            throw new MojoExecutionException("Error generating Java classes from: " + currentSourcePath, e);
-        }
-    }
+		try {
+			configuration.setBasePackageName(basePackageName);
+			configuration.setJaxrsVersion(JaxrsVersion.fromAlias(jaxrsVersion));
+			configuration.setOutputDirectory(outputDirectory);
+			configuration.setUseJsr303Annotations(useJsr303Annotations);
+			configuration.setAsyncResourceTrait(asyncResourceTrait);
+			configuration.setJsonMapper(AnnotationStyle.valueOf(jsonMapper.toUpperCase()));
+			configuration.setSourceDirectory(sourceDirectory);
+			configuration.setJsonMapperConfiguration(jsonMapperConfiguration);
+			configuration.setEmptyResponseReturnVoid(mapToVoid);
+			if (extensions != null) {
+				for (String className : extensions) {
+					Class c = Class.forName(className);
+					if (c == null) {
+						throw new MojoExecutionException("generatorExtensionClass " + className
+								+ " cannot be loaded."
+								+ "Have you installed the correct dependency in the plugin configuration?");
+					}
+					if (!((c.newInstance()) instanceof GeneratorExtension)) {
+						throw new MojoExecutionException("generatorExtensionClass " + className
+								+ " does not implement" + GeneratorExtension.class.getPackage() + "."
+								+ GeneratorExtension.class.getName());
 
-    private Collection<File> getRamlFiles() throws MojoExecutionException
-    {
-				if (sourcePaths != null && sourcePaths.length > 0 )
-				{
-            final List<File> sourceFiles = Arrays.asList(sourcePaths);
-            getLog().info("Using RAML files: " + sourceFiles);
-            return sourceFiles;
+					}
+					configuration.getExtensions().add((GeneratorExtension) c.newInstance());
+
+
 				}
-				else
-        {
-            if (!sourceDirectory.isDirectory())
-            {
-                throw new MojoExecutionException("The provided path doesn't refer to a valid directory: "
-                                                 + sourceDirectory);
-            }
+			}
+			/*
+			 * if (methodThrowException != null) {
+			 * configuration.setMethodThrowException
+			 * (Class.forName(methodThrowException)); }
+			 */
+		} catch (final Exception e) {
+			throw new MojoExecutionException("Failed to configure plug-in", e);
+		}
 
-            getLog().info("Looking for RAML files in and below: " + sourceDirectory);
+		project.addCompileSourceRoot(outputDirectory.getPath());
 
-            return FileUtils.listFiles(sourceDirectory, new String[]{"raml", "yaml"}, true);
-        }
-    }
+		File currentSourcePath = null;
+
+		try {
+			final Generator generator = new Generator();
+
+			for (final File ramlFile : getRamlFiles()) {
+				getLog().info("Generating Java classes from: " + ramlFile);
+				currentSourcePath = ramlFile;
+				generator.run(new FileReader(ramlFile), configuration);
+			}
+		} catch (final Exception e) {
+			throw new MojoExecutionException("Error generating Java classes from: " + currentSourcePath, e);
+		}
+	}
+
+	private Collection<File> getRamlFiles() throws MojoExecutionException {
+		if (sourcePaths != null && sourcePaths.length > 0) {
+			final List<File> sourceFiles = Arrays.asList(sourcePaths);
+			getLog().info("Using RAML files: " + sourceFiles);
+			return sourceFiles;
+		} else {
+			if (!sourceDirectory.isDirectory()) {
+				throw new MojoExecutionException("The provided path doesn't refer to a valid directory: "
+						+ sourceDirectory);
+			}
+
+			getLog().info("Looking for RAML files in and below: " + sourceDirectory);
+
+			return FileUtils.listFiles(sourceDirectory, new String[] { "raml", "yaml" }, true);
+		}
+	}
 }


### PR DESCRIPTION
Added a mechanism that allows users to register extensions that receive callbacks during various phases of code generation. This mechanism can be used to control and augment code generation without modifying raml-for-jax-rs. 
* The method `onCreateResourceInterface` is called immediately after generating the Java interface for a resource
* Similarly, `onAddResourceMethod` is called after generating the Java method that corresponds to a resource action.  
* Lastly, `AddParameterFilter` is called when a new Parameter (e.g., URLParameter, QueryParameter, etc). is created.  The extension can filter out a parameter by returning false to this call.

Currently only integrated with the maven plugin. See maven-plugin.md for instructions.
I will integrate with the command line and eclipse entry points if you will integrate.
