### PR TITLE
Config to customize the model package name

### DIFF
--- a/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/Configuration.java
+++ b/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/Configuration.java
@@ -67,6 +67,7 @@ public class Configuration
     private File outputDirectory;
     private JaxrsVersion jaxrsVersion = JaxrsVersion.JAXRS_1_1;
     private String basePackageName;
+    private String modelPackageName = "model";
     private boolean useJsr303Annotations = false;
     private AnnotationStyle jsonMapper = AnnotationStyle.JACKSON1;
     private File sourceDirectory;
@@ -75,7 +76,7 @@ public class Configuration
     private String asyncResourceTrait;
 	private boolean emptyResponseReturnVoid;
 	private boolean generateClientInterface;
-	
+
 	/**
 	 * <p>isGenerateClientInterface.</p>
 	 *
@@ -95,8 +96,8 @@ public class Configuration
 	}
 
 	private List<GeneratorExtension> extensions = new ArrayList<GeneratorExtension>();
-    
-    
+
+
 
 	/**
 	 * <p>Getter for the field <code>asyncResourceTrait</code>.</p>
@@ -107,7 +108,7 @@ public class Configuration
     {
          return asyncResourceTrait;
     }
-    
+
     /**
      * <p>Setter for the field <code>asyncResourceTrait</code>.</p>
      *
@@ -236,6 +237,26 @@ public class Configuration
     }
 
     /**
+     * <p>Getter for the field <code>modelPackageName</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    public String getModelPackageName()
+    {
+        return modelPackageName;
+    }
+
+    /**
+     * <p>Setter for the field <code>modelPackageName</code>.</p>
+     *
+     * @param modelPackageName a {@link java.lang.String} object.
+     */
+    public void setModelPackageName(final String modelPackageName)
+    {
+        this.modelPackageName = modelPackageName;
+    }
+
+    /**
      * <p>isUseJsr303Annotations.</p>
      *
      * @return a boolean.
@@ -274,7 +295,7 @@ public class Configuration
     {
         this.jsonMapper = jsonMapper;
     }
-    
+
     /**
      * <p>Getter for the field <code>methodThrowException</code>.</p>
      *
@@ -283,7 +304,7 @@ public class Configuration
     public Class getMethodThrowException() {
         return methodThrowException;
     }
-    
+
     /**
      * <p>Setter for the field <code>methodThrowException</code>.</p>
      *
@@ -310,7 +331,7 @@ public class Configuration
     public void setSourceDirectory(File sourceDirectory) {
         this.sourceDirectory = sourceDirectory;
     }
-    
+
     /**
      * <p>Getter for the field <code>jsonMapperConfiguration</code>.</p>
      *
@@ -320,7 +341,7 @@ public class Configuration
     {
        return jsonMapperConfiguration;
     }
-    
+
     /**
      * <p>Setter for the field <code>jsonMapperConfiguration</code>.</p>
      *
@@ -339,7 +360,7 @@ public class Configuration
 	public boolean isEmptyResponseReturnVoid() {
 		return emptyResponseReturnVoid;
 	}
-	
+
 	/**
 	 * <p>Setter for the field <code>emptyResponseReturnVoid</code>.</p>
 	 *
@@ -348,7 +369,7 @@ public class Configuration
 	public void setEmptyResponseReturnVoid(boolean emptyResponseReturnVoid) {
 		this.emptyResponseReturnVoid = emptyResponseReturnVoid;
 	}
-	
+
 	/**
 	 * <p>Getter for the field <code>extensions</code>.</p>
 	 *
@@ -357,6 +378,6 @@ public class Configuration
 	public List<GeneratorExtension> getExtensions() {
 		return this.extensions;
 	}
-	
+
 
 }

--- a/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/Context.java
+++ b/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/Context.java
@@ -99,7 +99,7 @@ class Context
     public JType ref(String name){
     	return codeModel.ref(name);
     }
-    
+
     /**
      * <p>Constructor for Context.</p>
      *
@@ -428,7 +428,9 @@ class Context
 
     private String getModelPackage()
     {
-        return configuration.getBasePackageName() + ".model";
+        return configuration.getBasePackageName()
+            .concat(".")
+            .concat(configuration.getModelPackageName());
     }
 
     private String getSupportPackage()

--- a/raml-to-jaxrs/maven-plugin/src/main/java/org/raml/jaxrs/codegen/maven/RamlJaxrsCodegenMojo.java
+++ b/raml-to-jaxrs/maven-plugin/src/main/java/org/raml/jaxrs/codegen/maven/RamlJaxrsCodegenMojo.java
@@ -88,6 +88,19 @@ public class RamlJaxrsCodegenMojo extends AbstractMojo {
 	private String basePackageName;
 
 	/**
+	 * Model package name used for generated Java classes.
+	 * Models will be placed in the package:
+	 *
+	 *   basePackageName + "." + modelPackageName
+	 *
+	 * The default location is set to:
+	 *
+	 *   basePackageName + ".model"
+	 */
+	@Parameter(property = "modelPackageName", defaultValue = "model")
+	private String modelPackageName;
+
+	/**
 	 * Should JSR-303 annotations be used?
 	 */
 	@Parameter(property = "useJsr303Annotations", defaultValue = "false")
@@ -172,6 +185,7 @@ public class RamlJaxrsCodegenMojo extends AbstractMojo {
 
 		try {
 			configuration.setBasePackageName(basePackageName);
+			configuration.setModelPackageName(modelPackageName);
 			configuration.setJaxrsVersion(JaxrsVersion.fromAlias(jaxrsVersion));
 			configuration.setOutputDirectory(outputDirectory);
 			configuration.setUseJsr303Annotations(useJsr303Annotations);


### PR DESCRIPTION
The default directory for all the generated model objects are in the package:

  basePackageName + ".model"

This encourages the anemic domain model anti-pattern as described in: http://www.martinfowler.com/bliki/AnemicDomainModel.html

Instead, the auto-generated models are actually just DTOs. To support teams that want better package naming of the auto-generated models, there is now an optional configuration to support overriding the default. Now, you can specify:

```
<plugin>
        <groupId>org.raml.plugins</groupId>
        <artifactId>raml-jaxrs-maven-plugin</artifactId>
        <configuration>
          <basePackageName>org.companyname</basePackageName>
          <modelPackageName>dto</modelPackageName>
       </configuration>
 </plugin>
```

And the models will be put in the "org.companyname.dto" package instead of the default "org.companyname.model"
