### PR TITLE
Reducing ambiguity with generated resources

### DIFF
--- a/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/Names.java
+++ b/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/Names.java
@@ -56,7 +56,7 @@ public class Names
         final String resourceInterfaceName = buildJavaFriendlyName(defaultIfBlank(resource.getDisplayName(),
             resource.getRelativeUri()));
 
-        return isBlank(resourceInterfaceName) ? "Root" : resourceInterfaceName;
+        return isBlank(resourceInterfaceName) ? "Root" : resourceInterfaceName.concat("Resource");
     }
 
     /**

--- a/raml-to-jaxrs/examples/jersey-example/src/main/java/org/raml/jaxrs/example/Main.java
+++ b/raml-to-jaxrs/examples/jersey-example/src/main/java/org/raml/jaxrs/example/Main.java
@@ -22,7 +22,7 @@ import java.util.Scanner;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.simple.SimpleContainerFactory;
-import org.raml.jaxrs.example.impl.PresentationResource;
+import org.raml.jaxrs.example.impl.PresentationResourceImpl;
 
 /**
  * <p>Main class.</p>
@@ -42,7 +42,7 @@ public class Main
     public static void main(final String[] args) throws Exception
     {
         final ResourceConfig config = new ResourceConfig();
-        config.register(PresentationResource.class);
+        config.register(PresentationResourceImpl.class);
         config.register(MultiPartFeature.class);
 
         final Closeable simpleContainer = SimpleContainerFactory.create(new URI("http://0.0.0.0:8181"),

--- a/raml-to-jaxrs/examples/jersey-example/src/main/java/org/raml/jaxrs/example/impl/PresentationResourceImpl.java
+++ b/raml-to-jaxrs/examples/jersey-example/src/main/java/org/raml/jaxrs/example/impl/PresentationResourceImpl.java
@@ -16,7 +16,8 @@
 package org.raml.jaxrs.example.impl;
 
 import org.raml.jaxrs.example.model.Presentation;
-import org.raml.jaxrs.example.resource.Presentations;
+import org.raml.jaxrs.example.model.Presentations;
+import org.raml.jaxrs.example.resource.PresentationsResource;
 
 /**
  * <p>PresentationResource class.</p>
@@ -24,7 +25,7 @@ import org.raml.jaxrs.example.resource.Presentations;
  * @author kor
  * @version $Id: $Id
  */
-public class PresentationResource implements Presentations
+public class PresentationResourceImpl implements PresentationsResource
 {
     /** {@inheritDoc} */
     @Override
@@ -38,7 +39,7 @@ public class PresentationResource implements Presentations
             return GetPresentationsResponse.withUnauthorized();
         }
 
-        final org.raml.jaxrs.example.model.Presentations presentations = new org.raml.jaxrs.example.model.Presentations().withSize(1);
+        final Presentations presentations = new Presentations().withSize(1);
 
         presentations.getPresentations().add(new Presentation().withId("fake-id").withTitle(title));
 


### PR DESCRIPTION
The autogenerated models and resources share the same class name and it causes lots of confusion when you attempt to use the autogenerated code. If you had a resource called "automobiles", raml-to-jaxrs will previously create both an Automobiles resource and an Automobiles model. When you attempt to use both at the same time, java will force you to fully qualify the package names which makes the code unwieldily to look at.

This change will simply add the suffix of "Resource" to each of the autogenerated resource. Now the same resource above will be called "AutomobilesResource" and the model will continue to be called "Automobiles".