### PR TITLE
Fix #54

### DIFF
--- a/raml-to-jaxrs/core/pom.xml
+++ b/raml-to-jaxrs/core/pom.xml
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>org.raml</groupId>
             <artifactId>raml-parser</artifactId>
-            <version>0.9-20150218.154027-76</version>            
+            <version>0.8.11</version>            
         </dependency>
 
         <dependency>


### PR DESCRIPTION
References maven central release version of org.raml/raml-parser instead of snapshot. Builds successfully with "mvn clean install".