### PR TITLE
Upgrade gradle to 2.2, License header fix

### DIFF
--- a/raml-to-jaxrs/gradle-plugin/LICENSE_HEADER.txt
+++ b/raml-to-jaxrs/gradle-plugin/LICENSE_HEADER.txt
@@ -1,4 +1,4 @@
-Copyright ${license.year} (c) MuleSoft, Inc.
+Copyright ${year} (c) MuleSoft, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/raml-to-jaxrs/gradle-plugin/build.gradle
+++ b/raml-to-jaxrs/gradle-plugin/build.gradle
@@ -37,8 +37,8 @@ buildscript {
 }
 
 ext {
-    gradleVersion = '1.11'
-    spockVersion = '0.7-groovy-1.8' // Gradle API currently uses 1.8.6 of Groovy and there is no way to exclude/replace it (currently).
+    gradleVersion = '2.2'
+    spockVersion = '1.0-groovy-2.3' // Gradle API currently uses 1.8.6 of Groovy and there is no way to exclude/replace it (currently).
 }
 
 repositories {
@@ -73,7 +73,8 @@ test {
 }
 
 license {
-    header rootProject.file('../LICENSE_HEADER.txt')
+	ext.year = '2013-'+Calendar.getInstance().get(Calendar.YEAR)
+    header rootProject.file('LICENSE_HEADER.txt')
     // false for now until we can exclude *.properties without causing it to be excluded from the generated jar
     // If you add a sourceSet to exclude the properties file as the documentation suggets, it also ends up
     // excluding the properties file from the packaged JAR.  This is an issue, as the raml.properties file is
@@ -82,5 +83,6 @@ license {
     mapping {
         java='SLASHSTAR_STYLE'
         groovy='SLASHSTAR_STYLE'
+        properties='SCRIPT_STYLE'
     }
 }

--- a/raml-to-jaxrs/gradle-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/raml-to-jaxrs/gradle-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.11-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2-bin.zip

--- a/raml-to-jaxrs/gradle-plugin/src/main/resources/META-INF/gradle-plugins/raml.properties
+++ b/raml-to-jaxrs/gradle-plugin/src/main/resources/META-INF/gradle-plugins/raml.properties
@@ -1,4 +1,4 @@
-# Copyright 2013 (c) MuleSoft, Inc.
+# Copyright 2013-2015 (c) MuleSoft, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Upgraded gradle to 2.2 and fixed lincense warning