### PR TITLE
Added optional input parameters to customize the package structure

### DIFF
--- a/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/AbstractGenerator.java
+++ b/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/AbstractGenerator.java
@@ -218,7 +218,7 @@ public abstract class AbstractGenerator {
 		types.generateClassesFromXmlSchemas(resources);
 
 		for (final Resource resource : resources) {
-			createResourceInterface(resource, raml);
+			createResourceInterface(resource, raml,configuration);
 		}
 
 		return context.generate();
@@ -232,9 +232,9 @@ public abstract class AbstractGenerator {
 	 * @throws java.lang.Exception if any.
 	 */
 	protected void createResourceInterface(final Resource resource,
-			final Raml raml) throws Exception {
+			final Raml raml,Configuration config) throws Exception {
 		final String resourceInterfaceName = Names
-				.buildResourceInterfaceName(resource);
+				.buildResourceInterfaceName(resource,config);
 		final JDefinedClass resourceInterface = context
 				.createResourceInterface(resourceInterfaceName);
 		context.setCurrentResourceInterface(resourceInterface);

--- a/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/Configuration.java
+++ b/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/Configuration.java
@@ -78,6 +78,8 @@ public class Configuration
 	private boolean emptyResponseReturnVoid;
 	private boolean generateClientInterface;
     private Class customAnnotator= NoopAnnotator.class;
+    private String restIFPackageName = "resource" ;
+    private String interfaceNameSuffix = "Resource" ;
 
     public ArrayList<String> getIgnoredParameterNames() {
         return ignoredParameterNames;
@@ -411,6 +413,22 @@ public class Configuration
 	 */
 	public List<GeneratorExtension> getExtensions() {
 		return this.extensions;
+	}
+
+	public String getRestIFPackageName() {
+		return restIFPackageName;
+	}
+
+	public void setRestIFPackageName(String restIFPackageName) {
+		this.restIFPackageName = restIFPackageName;
+	}
+
+	public String getInterfaceNameSuffix() {
+		return interfaceNameSuffix;
+	}
+
+	public void setInterfaceNameSuffix(String interfaceNameSuffix) {
+		this.interfaceNameSuffix = interfaceNameSuffix;
 	}
 
 

--- a/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/Context.java
+++ b/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/Context.java
@@ -294,7 +294,7 @@ class Context
             }
         }
 
-        final JPackage pkg = codeModel._package(configuration.getBasePackageName() + ".resource");
+        final JPackage pkg = codeModel._package(configuration.getBasePackageName() + "." +configuration.getRestIFPackageName());
         return pkg._interface(actualName);
     }
 
@@ -447,7 +447,7 @@ class Context
 
     private String getSupportPackage()
     {
-        return configuration.getBasePackageName() + ".support";
+        return configuration.getBasePackageName() + "." +configuration.getRestIFPackageName() +".support";
     }
 
     /**

--- a/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/Generator.java
+++ b/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/Generator.java
@@ -93,9 +93,9 @@ public class Generator extends AbstractGenerator
     
 
     /** {@inheritDoc} */
-    protected void createResourceInterface(final Resource resource, final Raml raml) throws Exception
+    protected void createResourceInterface(final Resource resource, final Raml raml,Configuration config) throws Exception
     {
-        final String resourceInterfaceName = Names.buildResourceInterfaceName(resource);
+        final String resourceInterfaceName = Names.buildResourceInterfaceName(resource,config);
         final JDefinedClass resourceInterface = context.createResourceInterface(resourceInterfaceName);
         context.setCurrentResourceInterface(resourceInterface);
 

--- a/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/Launcher.java
+++ b/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/Launcher.java
@@ -120,6 +120,9 @@ public class Launcher {
 		boolean useJsr303Annotations = false;
 		boolean mapToVoid = false;
 		String jsonMapper = "jackson1";
+		String modelPackageName = "model";
+		String restIFPackageName = "resource";
+		String interfaceNameSuffix = "Resource";
 		
 		
 		for( Map.Entry<String,String> entry : argMap.entrySet() ){
@@ -148,6 +151,15 @@ public class Launcher {
 			else if(argName.equals("jsonMapper")){
 				jsonMapper = argValue;
 			}
+			else if(argName.equals("modelPackageName")){
+				modelPackageName = argValue;
+			}
+			else if(argName.equals("restIFPackageName")){
+				restIFPackageName = argValue;
+			}
+			else if(argName.equals("interfaceNameSuffix")){
+				interfaceNameSuffix = argValue;
+			}
 		}
 		if(basePackageName==null){
 			throw new RuntimeException("Base package must be specified.");
@@ -162,6 +174,9 @@ public class Launcher {
         configuration.setUseJsr303Annotations(useJsr303Annotations);
         configuration.setJsonMapper(AnnotationStyle.valueOf(jsonMapper.toUpperCase()));
         configuration.setSourceDirectory(sourceDirectory);
+        configuration.setModelPackageName(modelPackageName);
+        configuration.setRestIFPackageName(restIFPackageName);
+        configuration.setInterfaceNameSuffix(interfaceNameSuffix);
         
         return configuration;
 	}

--- a/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/Names.java
+++ b/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/Names.java
@@ -58,12 +58,13 @@ public class Names
      * @param resource a {@link org.raml.model.Resource} object.
      * @return a {@link java.lang.String} object.
      */
-    public static String buildResourceInterfaceName(final Resource resource)
+    public static String buildResourceInterfaceName(final Resource resource,Configuration config)
     {
         final String resourceInterfaceName = buildJavaFriendlyName(defaultIfBlank(resource.getDisplayName(),
                 resource.getRelativeUri()));
 
-        return isBlank(resourceInterfaceName) ? "Root" : resourceInterfaceName.concat("Resource");
+        //return isBlank(resourceInterfaceName) ? "Root" : resourceInterfaceName.concat("Resource");
+        return isBlank(resourceInterfaceName) ? "Root" : resourceInterfaceName.concat(config.getInterfaceNameSuffix());
     }
 
     /**


### PR DESCRIPTION
Currently all the interfaces are getting created under resources folder
and similarly the pojo's are getting created under model folder. I have
modified the code to take these folder name as  optional input
parameters ,so that if provided the code get created as per the inputs
,if these optional parameters are not provided then the tool will behave
as it behaves now.