### PR TITLE
Fix gradle plugin build for maven 3.3

### DIFF
--- a/raml-to-jaxrs/gradle-plugin/pom.xml
+++ b/raml-to-jaxrs/gradle-plugin/pom.xml
@@ -20,7 +20,7 @@
    <plugin>
       <groupId>org.fortasoft</groupId>
       <artifactId>gradle-maven-plugin</artifactId>
-      <version>1.0.5</version>
+      <version>1.0.7</version>
         <configuration>
             <tasks>
             <task>testClasses</task>


### PR DESCRIPTION
Use version 1.0.7 of the  gradle-maven-plugin to address compatibility issues with maven 3.3

Version 1.0.5 of the gradle-maven-plugin will cause the build to fail with the message: 

     [ERROR] Failed to execute goal org.fortasoft:gradle-maven-plugin:1.0.5:invoke (default) on project raml-gradle-plugin: Execution default of goal org.fortasoft:gradle-maven-plugin:1.0.5:invoke failed: A required class was missing while executing org.fortasoft:gradle-maven-plugin:1.0.5:invoke: org/slf4j/impl/NewMojoLogger

Version 1.0.7 fixes this issue.
