### PR TITLE
Fix for relative includes

### DIFF
--- a/raml-to-jaxrs/core/pom.xml
+++ b/raml-to-jaxrs/core/pom.xml
@@ -96,7 +96,7 @@
         <dependency>
             <groupId>org.jsonschema2pojo</groupId>
             <artifactId>jsonschema2pojo-core</artifactId>
-            <version>0.4.11</version>
+            <version>0.4.16</version>
             <exclusions>
             	<exclusion>
             		<artifactId>jackson-databind</artifactId>

--- a/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/Configuration.java
+++ b/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/Configuration.java
@@ -160,6 +160,13 @@ public class Configuration
             {
                 return useJsr303Annotations;
             }
+            
+            @Override
+            public boolean isUseCommonsLang3()
+            {
+                return getConfiguredValue("useCommonsLang3", false);
+            }
+            
             @Override
             public boolean isGenerateBuilders()
             {

--- a/raml-to-jaxrs/gradle-plugin/build.gradle
+++ b/raml-to-jaxrs/gradle-plugin/build.gradle
@@ -56,6 +56,7 @@ dependencies {
     compile localGroovy()
     compile "org.raml:raml-jaxrs-codegen-core:1.3.4-SNAPSHOT"
     compile 'commons-io:commons-io:2.4'
+    compile 'org.jsonschema2pojo:jsonschema2pojo-core:0.4.16'
 
     testCompile("org.spockframework:spock-core:$spockVersion") {
         exclude group: 'org.codehaus.groovy', module: 'groovy-all'

--- a/raml-to-jaxrs/gradle-plugin/build.gradle
+++ b/raml-to-jaxrs/gradle-plugin/build.gradle
@@ -56,7 +56,6 @@ dependencies {
     compile localGroovy()
     compile "org.raml:raml-jaxrs-codegen-core:1.3.4-SNAPSHOT"
     compile 'commons-io:commons-io:2.4'
-    compile 'org.jsonschema2pojo:jsonschema2pojo-core:0.4.16'
 
     testCompile("org.spockframework:spock-core:$spockVersion") {
         exclude group: 'org.codehaus.groovy', module: 'groovy-all'

--- a/raml-to-jaxrs/gradle-plugin/src/main/groovy/org/raml/jaxrs/gradle/codegen/CodeGeneratorTask.groovy
+++ b/raml-to-jaxrs/gradle-plugin/src/main/groovy/org/raml/jaxrs/gradle/codegen/CodeGeneratorTask.groovy
@@ -162,7 +162,8 @@ class CodeGeneratorTask extends DefaultTask {
 		}
 
 		getRamlFiles().each { configurationFile ->
-			generator.run(new FileReader(configurationFile), ramlConfiguration)
+			ramlConfiguration.sourceDirectory = configurationFile.parentFile
+			generator.run(new FileReader(configurationFile), ramlConfiguration, configurationFile.absolutePath)
 		}
 	}
 }

--- a/raml-to-jaxrs/gradle-plugin/src/test/groovy/org/raml/jaxrs/gradle/codegen/CodeGeneratorTaskSpec.groovy
+++ b/raml-to-jaxrs/gradle-plugin/src/test/groovy/org/raml/jaxrs/gradle/codegen/CodeGeneratorTaskSpec.groovy
@@ -54,6 +54,6 @@ class CodeGeneratorTaskSpec extends Specification {
             generatorTask.configuration = configuration
             generatorTask.generate()
         then:
-            1 * generatorTask.generator.run(_,_)
+            1 * generatorTask.generator.run(_,_,_)
     }
 }


### PR DESCRIPTION
I needed to generate some JAX-RS code from RAML that had relative includes. The maven plugin handled that situation but the gradle plugin did not. This change will fix the issue with relative includes.