### PR TITLE
Integer queryParameter must generate int not long.

### DIFF
--- a/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/Types.java
+++ b/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/Types.java
@@ -299,7 +299,7 @@ public class Types
             case FILE :
                 return File.class;
             case INTEGER :
-                return usePrimitive ? long.class : Long.class;
+                return usePrimitive ? int.class : Integer.class;
             case NUMBER :
                 return BigDecimal.class;
             case STRING :


### PR DESCRIPTION
Input validation already assumes an Integer. See https://github.com/mulesoft/raml-for-jax-rs/blob/719395342e976437e1af5b9b2e2703018b76488c/jaxrs-to-raml/com.mulesoft.jaxrs.raml.generator/src/org/raml/model/ParamType.java#L87