### PR TITLE
allows cli to specify more jsonschema2pojo configuration parameters

### DIFF
--- a/raml-to-jaxrs/core/pom.xml
+++ b/raml-to-jaxrs/core/pom.xml
@@ -96,7 +96,7 @@
         <dependency>
             <groupId>org.jsonschema2pojo</groupId>
             <artifactId>jsonschema2pojo-core</artifactId>
-            <version>0.4.11</version>
+            <version>0.4.15</version>
             <exclusions>
             	<exclusion>
             		<artifactId>jackson-databind</artifactId>

--- a/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/Configuration.java
+++ b/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/Configuration.java
@@ -429,5 +429,7 @@ public class Configuration
 		return this.extensions;
 	}
 
-
+    public void setExtensions(List<GeneratorExtension> extensions) {
+        this.extensions=extensions;
+    }
 }

--- a/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/Configuration.java
+++ b/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/Configuration.java
@@ -189,6 +189,12 @@ public class Configuration
             }
 
             @Override
+            public boolean isUseCommonsLang3()
+            {
+                return getConfiguredValue("useCommonsLang3", false);
+            }
+
+            @Override
             public boolean isIncludeConstructors() {
                 return getConfiguredValue("includeConstructors", super.isIncludeConstructors());
             }

--- a/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/Configuration.java
+++ b/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/Configuration.java
@@ -188,6 +188,22 @@ public class Configuration
                 return getConfiguredValue("useLongIntegers", false);
             }
 
+            @Override
+            public boolean isIncludeConstructors() {
+                return getConfiguredValue("includeConstructors", super.isIncludeConstructors());
+            }
+
+            @Override
+            public boolean isConstructorsRequiredPropertiesOnly() {
+                return getConfiguredValue("constructorsRequiredPropertiesOnly", super
+                        .isConstructorsRequiredPropertiesOnly());
+            }
+
+            @Override
+            public boolean isIncludeAccessors() {
+                return getConfiguredValue("includeAccessors", super.isIncludeAccessors());
+            }
+
             private boolean getConfiguredValue(final String key, final boolean def)
             {
                 if (jsonMapperConfiguration == null || jsonMapperConfiguration.isEmpty())

--- a/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/Launcher.java
+++ b/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/Launcher.java
@@ -119,6 +119,7 @@ public class Launcher {
 		String modelPackageName = "model";
 		String asyncResourceTrait = null;
 		String customAnnotator = null;
+		Map<String,String> jsonMapperConfiguration = new HashMap<String, String>();
 				
 		for( Map.Entry<String,String> entry : argMap.entrySet() ){
 			
@@ -161,7 +162,11 @@ public class Launcher {
 			else if(argName.equals("customAnnotator")){
 				customAnnotator = argValue;
 			}
-			
+			else if(argName.startsWith("jsonschema2pojo."))
+			{
+				String name = argName.substring("jsonschema2pojo.".length());
+				jsonMapperConfiguration.put(name, argValue);
+			}
 		}
 		if(basePackageName==null){
 			throw new RuntimeException("Base package must be specified.");
@@ -181,6 +186,7 @@ public class Launcher {
         configuration.setUseTitlePropertyWhenPossible(useTitlePropertyForSchemaNames);
 		configuration.setModelPackageName(modelPackageName);
 		configuration.setAsyncResourceTrait(asyncResourceTrait);
+		if(!jsonMapperConfiguration.isEmpty()) configuration.setJsonMapperConfiguration(jsonMapperConfiguration);
 
 		if(customAnnotator!=null && !customAnnotator.trim().isEmpty()){
 			try {

--- a/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/Launcher.java
+++ b/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/Launcher.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import org.apache.commons.io.FileUtils;
 import org.jsonschema2pojo.AnnotationStyle;
 import org.raml.jaxrs.codegen.core.Configuration.JaxrsVersion;
+import org.raml.jaxrs.codegen.core.ext.GeneratorExtension;
 
 /**
  * <p>Launcher class.</p>
@@ -119,6 +120,7 @@ public class Launcher {
 		String modelPackageName = "model";
 		String asyncResourceTrait = null;
 		String customAnnotator = null;
+		List<GeneratorExtension> extensions = null;
 		Map<String,String> jsonMapperConfiguration = new HashMap<String, String>();
 				
 		for( Map.Entry<String,String> entry : argMap.entrySet() ){
@@ -162,6 +164,18 @@ public class Launcher {
 			else if(argName.equals("customAnnotator")){
 				customAnnotator = argValue;
 			}
+			else if(argName.equals("extensions")){
+				extensions = new ArrayList<GeneratorExtension>();
+				String[] extensionClasses = argValue.split(", ");
+				for(String s: extensionClasses)
+				{
+					try {
+						extensions.add((GeneratorExtension) Class.forName(s).newInstance());
+					} catch (Exception e) {
+						throw new RuntimeException("unknown extension " + s);
+					}
+				}
+			}
 			else if(argName.startsWith("jsonschema2pojo."))
 			{
 				String name = argName.substring("jsonschema2pojo.".length());
@@ -186,6 +200,7 @@ public class Launcher {
         configuration.setUseTitlePropertyWhenPossible(useTitlePropertyForSchemaNames);
 		configuration.setModelPackageName(modelPackageName);
 		configuration.setAsyncResourceTrait(asyncResourceTrait);
+		if (extensions!=null) configuration.setExtensions(extensions);
 		if(!jsonMapperConfiguration.isEmpty()) configuration.setJsonMapperConfiguration(jsonMapperConfiguration);
 
 		if(customAnnotator!=null && !customAnnotator.trim().isEmpty()){


### PR DESCRIPTION
in my project i need to access some specific mapping features of jsonschema2pojo.
I'm using cli version of raml-to-jaxrs.

* updated jsonschema2pojo version from 0.4.11 to 0.4.15
* cli arguments starting with `"-jsonschema2pojo."` are passed to Configuration.jsonMapperConfiguration
* added support for following jsonschema2pojo  configurations:
 * includeConstructors
 * constructorsRequiredPropertiesOnly
 * includeAccessors
* added CLI "extensions" argument, to set a comma-separated list of third-party GeneratorExtension (they all must be on the classpath)