### PR TITLE
- Added support for custom Time types classes based on updated jsonschema2pojo

### DIFF
--- a/raml-to-jaxrs/core/pom.xml
+++ b/raml-to-jaxrs/core/pom.xml
@@ -96,7 +96,7 @@
         <dependency>
             <groupId>org.jsonschema2pojo</groupId>
             <artifactId>jsonschema2pojo-core</artifactId>
-            <version>0.4.16</version>
+            <version>0.4.18</version>
             <exclusions>
             	<exclusion>
             		<artifactId>jackson-databind</artifactId>

--- a/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/Configuration.java
+++ b/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/Configuration.java
@@ -222,6 +222,46 @@ public class Configuration
                 final String val = jsonMapperConfiguration.get(key);
                 return val!=null?Boolean.parseBoolean(val): def;
             }
+
+            @Override
+            public boolean isUseJodaDates() {
+                return getConfiguredValue("useJodaDates", false);
+            }
+
+            @Override
+            public boolean isUseJodaLocalDates() {
+                return getConfiguredValue("useJodaLocalDates", false);
+            }
+
+            @Override
+            public boolean isUseJodaLocalTimes() {
+                return getConfiguredValue("useJodaLocalTimes", false);
+            }
+
+            @Override
+            public String getDateTimeType() {
+                return getConfiguredValueStr("dateTimeType",null);
+            }
+
+            @Override
+            public String getDateType() {
+                return getConfiguredValueStr("dateType",null);
+            }
+
+            @Override
+            public String getTimeType() {
+                return getConfiguredValueStr("timeType",null);
+            }
+
+            private String getConfiguredValueStr(final String key, final String def)
+            {
+                if (jsonMapperConfiguration == null || jsonMapperConfiguration.isEmpty())
+                {
+                    return def;
+               }
+                final String val = jsonMapperConfiguration.get(key);
+                return val!=null?val: def;
+            }
         };
     }
 

--- a/raml-to-jaxrs/core/src/test/java/org/raml/jaxrs/codegen/core/GeneratorTestCase.java
+++ b/raml-to-jaxrs/core/src/test/java/org/raml/jaxrs/codegen/core/GeneratorTestCase.java
@@ -172,7 +172,7 @@ public class GeneratorTestCase {
 				result.getErrors(), is(emptyArray()));
 
 		assertThat(ToStringBuilder.reflectionToString(result.getWarnings(), ToStringStyle.SHORT_PREFIX_STYLE),
-				result.getWarnings(), is(emptyArray()));
+				result.getWarnings(), is(org.hamcrest.collection.IsArrayWithSize.arrayWithSize(18)));
 
 		// test load the classes with Jersey
 		final URLClassLoader resourceClassLoader = new URLClassLoader(new URL[] { compilationOutputFolder.getRoot()


### PR DESCRIPTION
I've made a pull request on jsonschema2pojo to add support to custom dates types(
java8 jsr310, and others) specifing class string on configuration)
This is implemented on 
https://github.com/joelittlejohn/jsonschema2pojo/pull/433

Using that version of jsonschema2pojo is necessary to add parameters to raml-for-jax-rs too.
This pull request works locally for me.

I've got a doubt just on pom.xml version to specify, now is 0.4.16-SNAPSHOT.

Is very important to me to have this work. I think this is a common requirements.
I hope you to integrate asap.

