### PR TITLE
Maven plugin is not generating the client interface

### DIFF
--- a/raml-to-jaxrs/maven-plugin/src/main/java/org/raml/jaxrs/codegen/maven/RamlJaxrsCodegenMojo.java
+++ b/raml-to-jaxrs/maven-plugin/src/main/java/org/raml/jaxrs/codegen/maven/RamlJaxrsCodegenMojo.java
@@ -38,7 +38,7 @@ import org.codehaus.plexus.util.StringUtils;
 import org.jsonschema2pojo.AnnotationStyle;
 import org.raml.jaxrs.codegen.core.Configuration;
 import org.raml.jaxrs.codegen.core.Configuration.JaxrsVersion;
-import org.raml.jaxrs.codegen.core.Generator;
+import org.raml.jaxrs.codegen.core.GeneratorProxy;
 import org.raml.jaxrs.codegen.core.ext.GeneratorExtension;
 
 /**
@@ -256,7 +256,7 @@ public class RamlJaxrsCodegenMojo extends AbstractMojo {
 		File currentSourcePath = null;
 
 		try {
-			final Generator generator = new Generator();
+			final GeneratorProxy generator = new GeneratorProxy();
 
 			for (final File ramlFile : getRamlFiles()) {
 				currentSourcePath = ramlFile;


### PR DESCRIPTION
When setting the "generateClientProxy" to true, a GeneratorProxy must be used so it can switch either to ClientGenerator or Generator; otherwise, using Generator will only generate the server interface, no matter what the value of "generateClientProxy" is.