### PR TITLE
NPE fix -- NPE during the processing fields of enum

### DIFF
--- a/jaxrs-to-raml/jaxrs-raml-maven-plugin/src/main/java/org/raml/jaxrs/codegen/spoon/SpoonProcessor.java
+++ b/jaxrs-to-raml/jaxrs-raml-maven-plugin/src/main/java/org/raml/jaxrs/codegen/spoon/SpoonProcessor.java
@@ -605,15 +605,17 @@ public class SpoonProcessor{
 	private IFieldModel processField(CtField<?> m, TypeModel ownerType) {
 		FieldModel fm=new FieldModel();
 		fillBasic(fm, m);
-		CtTypeReference<?> type = m.getType();
-		fillJAXBType(fm,type);
-		
-		String typeSimpleName = type.getSimpleName();
-		String typeQualifiedname = type.getQualifiedName();
-		if(typeSimpleName.equalsIgnoreCase(typeQualifiedname)){
-			for(ITypeParameter tp : ownerType.getTypeParameters()){			
-				if(typeSimpleName.equals(tp.getName())){
-					fm.setGeneric(true);
+		if (m.getType() != null) {
+			CtTypeReference<?> type = m.getType();
+			fillJAXBType(fm,type);
+
+			String typeSimpleName = type.getSimpleName();
+			String typeQualifiedName = type.getQualifiedName();
+			if(typeSimpleName.equalsIgnoreCase(typeQualifiedName)){
+				for(ITypeParameter tp : ownerType.getTypeParameters()){
+					if(typeSimpleName.equals(tp.getName())){
+						fm.setGeneric(true);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
enum classes are handled as usual classes. During the processing of its fields, which are actually enum values, a NPE is thrown because these fields don't have type.