### PR TITLE
CXF doesn't validate Json payload 

### DIFF
--- a/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/AbstractGenerator.java
+++ b/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/AbstractGenerator.java
@@ -22,7 +22,6 @@ import static org.apache.commons.lang.StringUtils.strip;
 import static org.apache.commons.lang.builder.ToStringStyle.SHORT_PREFIX_STYLE;
 import static org.raml.jaxrs.codegen.core.Names.EXAMPLE_PREFIX;
 import static org.raml.jaxrs.codegen.core.Names.GENERIC_PAYLOAD_ARGUMENT_NAME;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -39,8 +38,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.Map.Entry;
-
 import javax.mail.internet.MimeMultipart;
+import javax.validation.Valid;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
@@ -56,7 +55,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
-
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.Validate;
@@ -84,7 +82,6 @@ import org.raml.parser.visitor.RamlDocumentBuilder;
 import org.raml.parser.visitor.RamlValidationService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import com.google.common.base.Function;
 import com.google.common.collect.Lists;
 import com.sun.codemodel.JAnnotationArrayMember;
@@ -440,8 +437,13 @@ public abstract class AbstractGenerator {
 	private void addPlainBodyArgument(final MimeType bodyMimeType,
 			final JMethod method, final JDocComment javadoc) throws IOException {
 
-		method.param(types.getRequestEntityClass(bodyMimeType),
-				GENERIC_PAYLOAD_ARGUMENT_NAME);
+	    if(context.getConfiguration().isUseJsr303Annotations()) {
+            method.param(types.getRequestEntityClass(bodyMimeType),
+                    GENERIC_PAYLOAD_ARGUMENT_NAME).annotate(Valid.class);
+        } else {
+            method.param(types.getRequestEntityClass(bodyMimeType),
+                    GENERIC_PAYLOAD_ARGUMENT_NAME);
+        }
 
 		javadoc.addParam(GENERIC_PAYLOAD_ARGUMENT_NAME).add(
 				getPrefixedExampleOrBlank(bodyMimeType.getExample()));

--- a/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/Generator.java
+++ b/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/Generator.java
@@ -26,7 +26,6 @@ import static org.raml.jaxrs.codegen.core.Constants.RESPONSE_HEADER_WILDCARD_SYM
 import static org.raml.jaxrs.codegen.core.Names.EXAMPLE_PREFIX;
 import static org.raml.jaxrs.codegen.core.Names.GENERIC_PAYLOAD_ARGUMENT_NAME;
 import static org.raml.jaxrs.codegen.core.Names.MULTIPLE_RESPONSE_HEADERS_ARGUMENT_NAME;
-
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.math.BigDecimal;
@@ -35,9 +34,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-
 import javax.mail.internet.MimeMultipart;
 import javax.management.RuntimeErrorException;
+import javax.validation.Valid;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
@@ -54,7 +53,6 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response.ResponseBuilder;
-
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang.math.NumberUtils;
@@ -71,7 +69,6 @@ import org.raml.model.parameter.FormParameter;
 import org.raml.model.parameter.Header;
 import org.raml.model.parameter.QueryParameter;
 import org.raml.model.parameter.UriParameter;
-
 import com.sun.codemodel.JAnnotationArrayMember;
 import com.sun.codemodel.JAnnotationUse;
 import com.sun.codemodel.JBlock;
@@ -170,6 +167,10 @@ public class Generator extends AbstractGenerator
         // no way of doing this :(
         final JMethod method = context.createResourceMethod(resourceInterface, methodName,
             resourceMethodReturnType);
+        
+        if(configuration.isUseJsr303Annotations()) {
+            method.annotate(Valid.class);
+        }
         
         if (configuration.getMethodThrowException() != null ) {
             method._throws(configuration.getMethodThrowException());


### PR DESCRIPTION
CXF doesn't validate request and response payload if they are not annotated with @Valid for a complex type which has validation annotations in it.