### PR TITLE
add useSourceHierarchyInPackageName option 

### DIFF
--- a/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/Configuration.java
+++ b/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/Configuration.java
@@ -80,6 +80,7 @@ public class Configuration
     private Class customAnnotator= NoopAnnotator.class;
     private String restIFPackageName = "resource" ;
     private String interfaceNameSuffix = "Resource" ;
+    private boolean useSourceHierarchyInPackageName = false;
 
     public ArrayList<String> getIgnoredParameterNames() {
         return ignoredParameterNames;
@@ -294,7 +295,16 @@ public class Configuration
         this.basePackageName = basePackageName;
     }
 
-    /**
+
+	public boolean isUseSourceHierarchyInPackageName() {
+		return useSourceHierarchyInPackageName;
+	}
+
+	public void setUseSourceHierarchyInPackageName(boolean useSourceHierarchyInPackageName) {
+		this.useSourceHierarchyInPackageName = useSourceHierarchyInPackageName;
+	}
+
+	/**
      * <p>Getter for the field <code>modelPackageName</code>.</p>
      *
      * @return a {@link java.lang.String} object.

--- a/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/Context.java
+++ b/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/Context.java
@@ -133,9 +133,10 @@ class Context
         final GenerationConfig jsonSchemaGenerationConfig = configuration.createJsonSchemaGenerationConfig();
         schemaMapper = new SchemaMapper(new RuleFactory(jsonSchemaGenerationConfig, getAnnotator(jsonSchemaGenerationConfig),
                 new SchemaStore()), new SchemaGenerator());
+        
+     
 
     }
-
 
 
 

--- a/raml-to-jaxrs/examples/raml-maven-plugin-example/pom.xml
+++ b/raml-to-jaxrs/examples/raml-maven-plugin-example/pom.xml
@@ -21,6 +21,7 @@
               <!-- Optionally configure outputDirectory if you don't like the default value: ${project.build.directory}/generated-sources/raml-JAX-RS -->
               <!-- Replace with your package name -->
               <basePackageName>com.acme.api</basePackageName>
+              <useSourceHierarchyInPackageName>true</useSourceHierarchyInPackageName>
               <!-- Valid values: 1.1 2.0 -->
               <JAX-RSVersion>2.0</JAX-RSVersion>
               <useJsr303Annotations>false</useJsr303Annotations>

--- a/raml-to-jaxrs/examples/raml-maven-plugin-example/raml/widgets/v1/widget-api-v1.raml
+++ b/raml-to-jaxrs/examples/raml-maven-plugin-example/raml/widgets/v1/widget-api-v1.raml
@@ -1,0 +1,33 @@
+#%RAML 0.8
+---
+title: Widget API v1"
+version: v1
+schemas:
+  - widget: |
+      {  "$schema": "http://json-schema.org/draft-03/schema",
+         "type": "object",
+         "description": "A widget",
+         "properties": {
+           "id":  { "type": "string", "required": true },
+           "name":  { "type": "string", "required": true },
+           "description":  { "type": "string" }
+         }
+      }
+ 
+ 
+ 
+/widgets:
+   /{widgetId}:
+     uriParameters:
+        widgetId:
+          type: string
+     get:
+      description: |
+         Get a widget
+      responses:
+        200:
+         body:
+          application/json:
+            schema: widget
+
+

--- a/raml-to-jaxrs/examples/raml-maven-plugin-example/raml/widgets/v2/widget-api-v2.raml
+++ b/raml-to-jaxrs/examples/raml-maven-plugin-example/raml/widgets/v2/widget-api-v2.raml
@@ -1,0 +1,33 @@
+#%RAML 0.8
+---
+title: Widget API v2"
+version: v2
+schemas:
+  - widget: |
+      {  "$schema": "http://json-schema.org/draft-03/schema",
+         "type": "object",
+         "description": "A widget",
+         "properties": {
+           "id":  { "type": "string", "required": true },
+           "name":  { "type": "string", "required": true },
+           "description":  { "type": "string" }
+         }
+      }
+ 
+ 
+ 
+/widgets:
+   /{widgetId}:
+     uriParameters:
+        widgetId:
+          type: string
+     get:
+      description: |
+         Get a widget
+      responses:
+        200:
+         body:
+          application/json:
+            schema: widget
+
+

--- a/raml-to-jaxrs/maven-plugin/pom.xml
+++ b/raml-to-jaxrs/maven-plugin/pom.xml
@@ -34,6 +34,16 @@
 			<artifactId>maven-plugin-tools-annotations</artifactId>
 			<version>${org.apache.maven.plugin-tools.version}</version>
 		</dependency>
+		
+		
+		<!--  Test dependencies -->
+		<dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
+        </dependency>		
+
 	</dependencies>
 
 	<build>

--- a/raml-to-jaxrs/maven-plugin/src/test/java/org/raml/jaxrs/codegen/maven/RamlJaxrsCodegenMojoTest.java
+++ b/raml-to-jaxrs/maven-plugin/src/test/java/org/raml/jaxrs/codegen/maven/RamlJaxrsCodegenMojoTest.java
@@ -1,0 +1,54 @@
+package org.raml.jaxrs.codegen.maven;
+
+import java.io.File;
+
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.Test;
+
+
+
+public class RamlJaxrsCodegenMojoTest  {
+
+	private RamlJaxrsCodegenMojo mojo;
+
+	@Before
+	public void init() throws Exception {
+		mojo = new RamlJaxrsCodegenMojo();
+
+	}
+
+
+
+	@Test
+	public void testcomputeSubPackageNameUseHierarchy() throws Exception {
+		mojo.setBasePackageName("");
+		mojo.setSourceDirectory(new File("src/raml/"));
+		mojo.setUseSourceHiearchyInPackageName(true);
+		assertEquals(".v1", mojo.computeSubPackageName(new File("src/raml/v1/widgets.raml")));
+		assertEquals(".v2", mojo.computeSubPackageName(new File("src/raml/v2/widgets.raml")));
+		assertEquals("", mojo.computeSubPackageName(new File("src/raml/widgets.raml")));
+		assertEquals(".v1", mojo.computeSubPackageName(new File("src/raml/v1/widgets.raml")));
+	}
+	
+	@Test
+	public void testcomputeSubPackageNameNoHierarchy() throws Exception {
+		mojo.setBasePackageName("");
+		mojo.setSourceDirectory(new File("/src/raml/"));
+		mojo.setUseSourceHiearchyInPackageName(false);
+		assertEquals("", mojo.computeSubPackageName(new File("/src/raml/v1/widgets.raml")));
+		assertEquals("", mojo.computeSubPackageName(new File("/src/raml/v2/widgets.raml")));
+		assertEquals("", mojo.computeSubPackageName(new File("/src/raml/widgets.raml")));
+	}
+	
+	@Test
+	public void testcomputeSubPackageNameNoSourceDirectory() throws Exception {
+		mojo.setBasePackageName("");
+		mojo.setUseSourceHiearchyInPackageName(true);
+		mojo.setSourceDirectory(null);
+		assertEquals("", mojo.computeSubPackageName(new File("/src/raml/v1/widgets.raml")));
+		assertEquals("", mojo.computeSubPackageName(new File("/src/raml/v2/widgets.raml")));
+		assertEquals("", mojo.computeSubPackageName(new File("/src/raml/widgets.raml")));
+	}
+
+}


### PR DESCRIPTION
Add an option to use the source hierarchy in package naming.  For example if sourceDirectory is set to project/raml and the directory has v1/interface.raml and v2/interface.raml, the former will be generated in package ${basePackageName}.v1 and the latter in ${basePackageName}.v2
