### PR TITLE
Add support for resource class with version

### DIFF
--- a/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/ext/ResourceInterfaceNameWithVersion.java
+++ b/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/ext/ResourceInterfaceNameWithVersion.java
@@ -6,25 +6,21 @@ import org.raml.model.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Optional;
-import java.util.regex.Pattern;
-
 public class ResourceInterfaceNameWithVersion extends AbstractGeneratorExtension implements InterfaceNameBuilderExtension {
     private static final Logger LOGGER = LoggerFactory.getLogger(ResourceInterfaceNameWithVersion.class);
-    private static final Pattern VERSION_PATTERN = Pattern.compile("^v[0-9]+$");
 
     @Override
     public String buildResourceInterfaceName(Resource resource) {
         Configuration config = new Configuration();
         config.setInterfaceNameSuffix("Resource");
         String resourceName = Names.buildResourceInterfaceName(resource, config);
-        Optional<String> version = Optional.ofNullable(getRaml().getVersion());
-        if (version.isPresent() && VERSION_PATTERN.matcher(version.get()).matches()) {
-            resourceName += version.get().toUpperCase();
+        String version = getRaml().getVersion();
+        if (version != null) {
+            resourceName += version.toUpperCase();
             LOGGER.debug("Generated resource name: " + resourceName);
             return resourceName;
         }
-        String message = "Invalid version found in RAML: " + version;
+        String message = "No version found in RAML.";
         LOGGER.warn(message);
         throw new IllegalArgumentException(message);
     }

--- a/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/ext/ResourceInterfaceNameWithVersion.java
+++ b/raml-to-jaxrs/core/src/main/java/org/raml/jaxrs/codegen/core/ext/ResourceInterfaceNameWithVersion.java
@@ -1,0 +1,31 @@
+package org.raml.jaxrs.codegen.core.ext;
+
+import org.raml.jaxrs.codegen.core.Configuration;
+import org.raml.jaxrs.codegen.core.Names;
+import org.raml.model.Resource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+public class ResourceInterfaceNameWithVersion extends AbstractGeneratorExtension implements InterfaceNameBuilderExtension {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ResourceInterfaceNameWithVersion.class);
+    private static final Pattern VERSION_PATTERN = Pattern.compile("^v[0-9]+$");
+
+    @Override
+    public String buildResourceInterfaceName(Resource resource) {
+        Configuration config = new Configuration();
+        config.setInterfaceNameSuffix("Resource");
+        String resourceName = Names.buildResourceInterfaceName(resource, config);
+        Optional<String> version = Optional.ofNullable(getRaml().getVersion());
+        if (version.isPresent() && VERSION_PATTERN.matcher(version.get()).matches()) {
+            resourceName += version.get().toUpperCase();
+            LOGGER.debug("Generated resource name: " + resourceName);
+            return resourceName;
+        }
+        String message = "Invalid version found in RAML: " + version;
+        LOGGER.warn(message);
+        throw new IllegalArgumentException(message);
+    }
+}

--- a/raml-to-jaxrs/core/src/test/java/org/raml/jaxrs/codegen/core/ext/ResourceInterfaceNameWithVersionTest.java
+++ b/raml-to-jaxrs/core/src/test/java/org/raml/jaxrs/codegen/core/ext/ResourceInterfaceNameWithVersionTest.java
@@ -1,0 +1,47 @@
+package org.raml.jaxrs.codegen.core.ext;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.raml.model.Raml;
+import org.raml.model.Resource;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class ResourceInterfaceNameWithVersionTest {
+    public static final String BASE_URI = "http://api.example.org";
+    private ResourceInterfaceNameWithVersion resourceInterfaceNameWithVersion = new ResourceInterfaceNameWithVersion();
+    private Resource resource;
+    private Raml raml;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Before
+    public void init() {
+        resource = new Resource();
+        raml = new Raml();
+        resourceInterfaceNameWithVersion.setRaml(raml);
+        resource.setParentUri("");
+    }
+
+    @Test
+    public void testResourceNameWithVersion() throws Exception {
+        raml.setBaseUri(BASE_URI);
+        raml.setVersion("v1");
+        resource.setRelativeUri("/test");
+        String resourceInterfaceName = resourceInterfaceNameWithVersion.buildResourceInterfaceName(resource);
+        assertThat("Resource name does not have a version", resourceInterfaceName, is("TestResourceV1"));
+    }
+
+    @Test
+    public void testResourceNameWithoutVersion() throws Exception {
+        raml.setBaseUri(BASE_URI);
+        raml.setVersion(null);
+        resource.setRelativeUri("/test");
+        expectedException.expect(IllegalArgumentException.class);
+        resourceInterfaceNameWithVersion.buildResourceInterfaceName(resource);
+    }
+}


### PR DESCRIPTION
I'm using this locally but want to contribute this. 
The extension generates the resource class name with a version suffix based on the version in the RAML.